### PR TITLE
Fix  for "Could not jarsign apkFilename, used this command: jarsigner" on Windows systems

### DIFF
--- a/src/main/groovy/com/testfairy/plugins/gradle/TestFairyPlugin.groovy
+++ b/src/main/groovy/com/testfairy/plugins/gradle/TestFairyPlugin.groovy
@@ -165,7 +165,7 @@ class TestFairyPlugin implements Plugin<Project> {
 									project.logger.debug("Added api_key to download url, and is now ${instrumentedUrl}")
 
 									String baseName = FilenameUtils.getBaseName(apkFilename)
-									String tempFilename = "${tempDir}/testfairy-${baseName}.apk".toString()
+									String tempFilename = FilenameUtils.normalize("${tempDir}/testfairy-${baseName}.apk".toString());
 									project.logger.debug("Downloading instrumented APK onto ${tempFilename}")
 									downloadFile(instrumentedUrl, tempFilename)
 
@@ -289,7 +289,9 @@ class TestFairyPlugin implements Plugin<Project> {
 		HttpGet httpget = new HttpGet(url)
 		HttpResponse response = httpClient.execute(httpget)
 		HttpEntity entity = response.getEntity()
-		IOUtils.copy(entity.getContent(), new FileOutputStream(localFilename))
+        FileOutputStream fis = new FileOutputStream(localFilename);
+        IOUtils.copy(entity.getContent(), fis)
+        fis.close();
 	}
 
 	/**


### PR DESCRIPTION
Added FileInputStream close after copying instrumented apk for resign. Without that, jarsigner couldn't copy signed apk to temp file for upload (error was shown: Could not jarsign apkFilename, used this command: jarsigner...). Tested on 64bit Windows 7 system.

If there are other workarounds, please provide me one.
