### PR TITLE
Added support for custom digest and signing algorithm

### DIFF
--- a/src/main/groovy/com/testfairy/plugins/gradle/TestFairyExtension.groovy
+++ b/src/main/groovy/com/testfairy/plugins/gradle/TestFairyExtension.groovy
@@ -13,6 +13,8 @@ class TestFairyExtension {
 	private String maxDuration
 	private String metrics
 	private String comment
+	private String digestAlg = "SHA1"
+	private String sigAlg = "MD5withRSA"
 	private Boolean notify = true
 	private Boolean autoUpdate = false
 	private Boolean recordOnBackground = false
@@ -89,6 +91,22 @@ class TestFairyExtension {
 
 	void comment(String value) {
 		this.comment = value
+	}
+
+	String getDigestAlg() {
+		return digestAlg;
+	}
+
+	void digestAlg(String value) {
+		this.digestAlg = value;
+	}
+
+	String getSigAlg() {
+		return sigAlg;
+	}
+
+	void sigAlg(String value) {
+		this.sigAlg = value;
 	}
 
 	String getComment() {

--- a/src/main/groovy/com/testfairy/plugins/gradle/TestFairyPlugin.groovy
+++ b/src/main/groovy/com/testfairy/plugins/gradle/TestFairyPlugin.groovy
@@ -130,7 +130,7 @@ class TestFairyPlugin implements Plugin<Project> {
 									downloadFile(instrumentedUrl, tempFilename)
 
 									// resign using gradle build settings
-									resignApk(tempFilename, variant.signingConfig)
+									resignApk(tempFilename, variant.signingConfig, extension)
 
 									// upload the signed apk file back to testfairy
 									json = uploadSignedApk(project, extension, tempFilename)
@@ -463,14 +463,14 @@ class TestFairyPlugin implements Plugin<Project> {
 	 * @param apkFilename
 	 * @param sc
 	 */
-	void resignApk(String apkFilename, sc) {
+	void resignApk(String apkFilename, sc, extension) {
 
 		// use a temporary file in the same directory as apkFilename
 		String outFilename = apkFilename + ".temp"
 
 		// remove signature onto temp file, sign and zipalign back onto original filename
 		removeSignature(apkFilename, outFilename)
-		signApkFile(outFilename, sc)
+		signApkFile(outFilename, sc, extension)
 		zipAlignFile(outFilename, apkFilename)
 		(new File(outFilename)).delete()
 
@@ -484,8 +484,8 @@ class TestFairyPlugin implements Plugin<Project> {
 	 * @param apkFilename
 	 * @param sc
 	 */
-	void signApkFile(String apkFilename, sc) {
-		def command = [jarSignerPath, "-keystore", sc.storeFile, "-storepass", sc.storePassword, "-keypass", sc.keyPassword, "-digestalg", "SHA1", "-sigalg", "MD5withRSA", apkFilename, sc.keyAlias]
+	void signApkFile(String apkFilename, sc, extension) {
+		def command = [jarSignerPath, "-keystore", sc.storeFile, "-storepass", sc.storePassword, "-keypass", sc.keyPassword, "-digestalg", extension.getDigestAlg(), "-sigalg", extension.getSigAlg(), apkFilename, sc.keyAlias]
 		def proc = command.execute()
 		proc.consumeProcessOutput()
 		proc.waitFor()


### PR DESCRIPTION
This fixes cases when android keystores are signed with different algorithms that the ones currently hardcoded in the groovy file.

Just specify your desired config like this:

testfairyConfig {
        digestAlg "SHA1"
        sigAlg "SHA1withDSA"
}

https://github.com/testfairy/testfairy-gradle-plugin/issues/37
