### PR TITLE
Read ANDROID_HOME if no sdk.dir found in local.properties

### DIFF
--- a/src/main/groovy/com/testfairy/plugins/gradle/TestFairyPlugin.groovy
+++ b/src/main/groovy/com/testfairy/plugins/gradle/TestFairyPlugin.groovy
@@ -51,7 +51,8 @@ class TestFairyPlugin implements Plugin<Project> {
 		if (localProps.exists()) {
 			properties.load(localProps.newDataInputStream())
 			sdkDir = properties.getProperty('sdk.dir')
-		} else {
+		} 
+		if (!sdkDir) {
 			sdkDir = System.getenv('ANDROID_HOME')
 		}
 


### PR DESCRIPTION
It is not a given that local.properties will always contain a line with the sdk.dir

This change will fallback to env ANDROID_HOME if sdk.dir is not found local.properties
