### PR TITLE
Added support for Gradle 5.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Fork adds support for Gradle 5.4.1 and Android Gradle plugin 3.5.0
+
 TestFairy Gradle Plugin [![Build Status](https://travis-ci.org/testfairy/testfairy-gradle-plugin.svg?branch=master)](https://travis-ci.org/testfairy/testfairy-gradle-plugin) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 -------------------
 

--- a/src/main/groovy/com/testfairy/plugins/gradle/TestFairyPlugin.groovy
+++ b/src/main/groovy/com/testfairy/plugins/gradle/TestFairyPlugin.groovy
@@ -29,7 +29,7 @@ class TestFairyPlugin implements Plugin<Project> {
 				task.applicationVariant = variant
 				task.extension = extension
 				task.outputs.upToDateWhen { false }
-				task.dependsOn variant.assemble
+				task.dependsOn variant.assembleProvider
 			}
 		}
 	}


### PR DESCRIPTION
Added support for Gradle 5.4.1 and android Gradle plugin 3.5.0.
For Android builds without this it leads to:
> INFO: API 'variant.getAssemble()' is obsolete and has been replaced with 'variant.getAssembleProvider()'.